### PR TITLE
Stable test in flipud.

### DIFF
--- a/tests/chainer_tests/functions_tests/array_tests/test_flipud.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_flipud.py
@@ -51,7 +51,8 @@ class TestFlipUD(unittest.TestCase):
             return y * y
 
         gradient_check.check_double_backward(
-            f, x_data, y_grad, x_grad_grad, dtype=numpy.float64)
+            f, x_data, y_grad, x_grad_grad, dtype=numpy.float64,
+            atol=5e-4, rtol=5e-3)
 
     def test_double_backward_cpu(self):
         self.check_double_backward(self.x, self.gy, self.ggx)


### PR DESCRIPTION
Double backward test of `flipud` fails in rare case (once per a few thousands on my local).